### PR TITLE
Test On Windows && Fix Bug On Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ dist/
 
 # Temporary files
 tmp/
+
+.docker/

--- a/example/Readme.md
+++ b/example/Readme.md
@@ -14,7 +14,7 @@ The following table compares the total size of delivered images using different 
 | Separate Image Delivery |  1.8 GB    |  3.0 GB    |  1.8 GB    |   1.8 GB       |  **8.4 GB**|
 | Conda Pack Tarballs     |  1.8 GB    |  2.7 GB    |  1.8 GB    |   1.8 GB       |  **8.1 GB**|
 
-
+> **Note:** The benchmarks and results above are based on tests performed on a Linux platform. Results may vary on Windows due to differences in filesystem handling, image layer storage, and Docker implementation.
 
 ### Key Benefits
 **Consistent Runtime Environment:** By delivering the exact same Docker images, you can reliably reproduce the runtime environment on any host PC, ensuring your production and test environments are identical.
@@ -69,11 +69,7 @@ This example uses Docker's **additional contexts** feature to create a shared ba
 Run the following command from the project root directory:
 
 ```bash
-docker-deliver save \
-  -f example/docker-compose.base.yaml \
-  -f example/docker-compose.extend.yaml \
-  --tag latest \
-  -o tmp
+docker-deliver save -f example/docker-compose.base.yaml -f example/docker-compose.extend.yaml -o tmp
 ```
 
 ### Output Structure
@@ -138,7 +134,9 @@ To deploy the packaged project on another system:
 
 2. **Load images**:
    ```bash
-   docker load < images.tar
+   docker load < images.tar # Linux
+
+   docker load -i image.tar # Windows
    ```
 
 3. **Deploy services**:

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -143,7 +143,7 @@ func (c *ComposeClient) Build(ctx context.Context) error {
 	if backend == nil {
 		return err
 	}
-	if err := backend.Build(ctx, project, api.BuildOptions{}); err != nil {
+	if err := backend.Build(ctx, project, api.BuildOptions{Builder: "default"}); err != nil {
 		c.logger.Errorf("Failed to build project: %v", err)
 		return err
 	}

--- a/internal/compose/compose.go
+++ b/internal/compose/compose.go
@@ -135,6 +135,11 @@ func (c *ComposeClient) Build(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	// Set environment variables to handle Windows Docker Desktop compatibility
+	if os.Getenv("OS") == "Windows_NT" {
+		c.logger.Debug("Configuring Docker environment for Windows desktop-linux context")
+		os.Setenv("DOCKER_HOST", "npipe:////./pipe/dockerDesktopLinuxEngine")
+	}
 
 	if err := dockerCli.Initialize(flags.NewClientOptions()); err != nil {
 		return err
@@ -143,7 +148,7 @@ func (c *ComposeClient) Build(ctx context.Context) error {
 	if backend == nil {
 		return err
 	}
-	if err := backend.Build(ctx, project, api.BuildOptions{Builder: "default"}); err != nil {
+	if err := backend.Build(ctx, project, api.BuildOptions{}); err != nil {
 		c.logger.Errorf("Failed to build project: %v", err)
 		return err
 	}


### PR DESCRIPTION
## Issue
When Running on Windows, compose go sdk can't find buildx context `desktop-linux`

## Solution
os.Setenv("DOCKER_HOST", "npipe:////./pipe/dockerDesktopLinuxEngine") for windows plattform